### PR TITLE
Add callback parameter to script URL

### DIFF
--- a/src/Helpers/MapHelper.php
+++ b/src/Helpers/MapHelper.php
@@ -19,7 +19,13 @@ class MapHelper
 
     public static function googleMapsScriptUrl()
     {
-        return 'https://maps.googleapis.com/maps/api/js?libraries=places&key=' . config('google_maps.api_key');
+        $params = [
+            'callback' => 'Function.prototype',
+            'libraries' => 'places',
+            'key' => config('google_maps.api_key'),
+        ];
+        
+        return 'https://maps.googleapis.com/maps/api/js?' . http_build_query($params);
     }
 
     public static function convertToHtml(array $params)


### PR DESCRIPTION
It looks like Google Maps JS library started enforcing `callback` parameter which leads to an error printed in the console.
This address that according to [an answer at Stack Overflow](https://stackoverflow.com/questions/75179573/how-to-fix-loading-the-google-maps-javascript-api-without-a-callback-is-not-supp).